### PR TITLE
Fix name to sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author_email='f@bianp.net',
     url='https://pypi.python.org/pypi/mord',
     packages=['mord'],
-    requires=['numpy', 'scipy', "scikit-learn"],
+    requires=['numpy', 'scipy', "sklearn"],
 )


### PR DESCRIPTION
Don't import the module to get the version number.
Pip can't discover the dependencies without them already being installed.
Also added sklearn as a dependency